### PR TITLE
Mudança title página register Login para Cadastro

### DIFF
--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -2,7 +2,7 @@
 <html lang="pt-br" dir="ltr">
   <head>
     <meta charset="utf-8">
-    <title>Login</title>
+    <title>Cadastro</title>
     {% include 'imports.html' %}
     <script type="text/python"
       src={{url_for('static', filename='scripts/register.py')}}>


### PR DESCRIPTION
Correção do títuo da página de cadastro, mudança de "Login" para "Cadastro".

Alteração realizada no arquivo `app/templates/register.html`:

```html
<title>Cadastro</title>
```